### PR TITLE
Heart icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ node_modules
 
 # Bundle
 assets/js/bundle.js
+
+# Swap files
+*.swp

--- a/assets/js/components/organisms/SurveyQuestion.jsx
+++ b/assets/js/components/organisms/SurveyQuestion.jsx
@@ -55,6 +55,8 @@ class SurveyQuestion extends Component {
             <label>How strongly do you feel about this?</label><br />
             <Rating
               initialRate={this.props.question.intensity}
+              empty='glyphicon glyphicon-heart-empty'
+              full='glyphicon glyphicon-heart'
               onChange={this.setRating.bind(this)} />
           </Well>
         }

--- a/package.json
+++ b/package.json
@@ -61,10 +61,12 @@
     "babel-loader": "^6.2.0",
     "browser-sync": "^2.10.1",
     "browser-sync-webpack-plugin": "^1.0.1",
+    "chai": "^3.5.0",
     "eslint": "^2.3.0",
     "eslint-config-trails": "^1.0.4",
     "eslint-loader": "^1.1.1",
     "eslint-plugin-react": "^3.13.0",
+    "mocha-jsdom": "^1.1.0",
     "redux-devtools": "^3.1.1",
     "webpack": "^1.12.9"
   }

--- a/test/frontend/components/organisms/SurveyQuestionTest.js
+++ b/test/frontend/components/organisms/SurveyQuestionTest.js
@@ -1,0 +1,70 @@
+import jsdom from 'mocha-jsdom'
+import React from 'react/addons'
+import { expect } from 'chai'
+import Rating from 'react-rating'
+import SurveyQuestion from '../../../../assets/js/components/organisms/SurveyQuestion'
+
+var TestUtils = React.addons.TestUtils;
+
+describe('The survey question component', () => {
+    let surveyQuestion;
+
+    beforeEach(() => {
+        let question = {
+            questionText: 'test',
+            answers: [
+                {id: 1, answerLabel: '1'},
+                {id: 2, answerLabel: '2'},
+                {id: 3, answerLabel: '3'}
+            ]
+        }
+        surveyQuestion = TestUtils.renderIntoDocument(
+            <SurveyQuestion question={ question } />
+        )
+    })
+
+    context('rating element', () => {
+        let rating
+
+        beforeEach(() => {
+            rating = TestUtils.scryRenderedComponentsWithType(
+                surveyQuestion, Rating)[0]
+        })
+
+        it('will exist', () => {
+            expect(rating).to.exist
+        })
+
+        context('property', () => {
+            let props
+
+            beforeEach(() => {
+                props = rating.props
+            })
+
+            context('empty', () => {
+                let empty
+
+                beforeEach(() => {
+                    empty = props.empty
+                })
+
+                it('will have a heart icon', () => {
+                    expect(empty).to.contain('heart-empty')
+                })
+            })
+
+            context('full', () => {
+                let full
+
+                beforeEach(() => {
+                    full = props.full
+                })
+
+                it('will have a heart icon', () => {
+                    expect(full).to.contain('heart')
+                })
+            })
+        })
+    })
+})


### PR DESCRIPTION
The following changes since commit 05432223b2d39e0fcda7a0a0650ad6b941856450:

  adding api tests (2016-03-30 00:44:28 -0400)

are available in the git repository at:

  https://github.com/ryayak1460/okcandidate.git heart-icons

for you to fetch changes up to 41507fec9e0a3805f8a8acc366a751c6ef6faf6c:

  Include skip all changes (2016-04-01 20:22:52 -0400)

----------------------------------------------------------------
Blaine Price (1):
      When all the questions have been answered (including the current) one, display next button. When one question remains, say 'last question' instead of '1 questions remaining'

Ryan Y (3):
      Ignore swap files
      Include Bootstrap heart styles
      Include skip all changes

W. Blaine Price (1):
      Merge pull request #58 from wbprice/48-user-survey-flow

 .gitignore                                         |  3 +
 .../components/ecosystems/SurveyQuestionPager.jsx  | 57 ++++++++++++++----
 assets/js/components/organisms/SurveyQuestion.jsx  |  2 +
 package.json                                       |  2 +
 .../components/organisms/SurveyQuestionTest.js     | 70 ++++++++++++++++++++++
 5 files changed, 122 insertions(+), 12 deletions(-)
 create mode 100644 test/frontend/components/organisms/SurveyQuestionTest.js
