### PR TITLE
Replace questions with single row

### DIFF
--- a/assets/js/components/atoms/Card.jsx
+++ b/assets/js/components/atoms/Card.jsx
@@ -33,7 +33,8 @@ class Card extends Component {
 
 Card.propTypes = {
   children: PropTypes.any,
-  style: PropTypes.object
+  style: PropTypes.object,
+  className: PropTypes.string
 }
 
 export default Card

--- a/assets/js/components/atoms/Card.jsx
+++ b/assets/js/components/atoms/Card.jsx
@@ -23,7 +23,7 @@ class Card extends Component {
 
   render() {
     return (
-      <section style={this.getStyle.call(this)}>
+      <section className={this.props.className} style={this.getStyle.call(this)}>
         {this.props.children}
       </section>
     )

--- a/assets/js/components/organisms/CandidateMatchCandidate.jsx
+++ b/assets/js/components/organisms/CandidateMatchCandidate.jsx
@@ -27,7 +27,7 @@ class CandidateMatchCandidate extends Component {
 
   render() {
     return (
-      <Card style={{marginBottom: '1em'}}>
+      <Card className="candidate-card" style={{marginBottom: '1em'}}>
         <div style={{display: 'flex'}}>
           <CandidateMatchProfileBadge
             candidateName={this.props.candidateName}

--- a/assets/js/components/organisms/CandidateMatchCategory.jsx
+++ b/assets/js/components/organisms/CandidateMatchCategory.jsx
@@ -1,36 +1,25 @@
 import React, { PropTypes, Component } from 'react'
-import CandidateMatchQuestion from './../organisms/CandidateMatchQuestion.jsx'
+import { Panel, Label } from 'react-bootstrap'
 
 class CandidateMatchCategory extends Component {
-
   constructor(props) {
     super(props)
   }
 
   render() {
     return (
-      <section>
-        <h6>{this.props.categoryName}</h6>
-        <dl>
-          <dt>Category Match</dt>
-          <dd>{this.props.categoryMatch}</dd>
-        </dl>
-        <h6>Questions</h6>
-        {
-          this.props.questions.map((question, index) => {
-            return (
-              <CandidateMatchQuestion
-                key={index}
-                questionText={question.questionText}
-                voterAnswerText={question.voterAnswerText}
-                candidateAnswerLabel={question.candidateAnswerLabel} />
-            )
-          })
-        }
-      </section>
+      <Panel>
+        <div style={{display: 'flex', alignItems: 'center'}}>
+          <h5 style={{flexGrow: 1}}>
+            {this.props.categoryName}
+          </h5>
+          <Label bsStyle="danger">
+            {this.props.categoryMatch}%
+          </Label>
+        </div>
+      </Panel>
     )
   }
-
 }
 
 CandidateMatchCategory.propTypes = {

--- a/assets/js/components/organisms/CandidateMatchCategory.jsx
+++ b/assets/js/components/organisms/CandidateMatchCategory.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes, Component } from 'react'
 import { Panel, Label } from 'react-bootstrap'
 
+import CandidateMatchRating from '../atoms/CandidateMatchRating.jsx'
+
 class CandidateMatchCategory extends Component {
   constructor(props) {
     super(props)
@@ -8,14 +10,13 @@ class CandidateMatchCategory extends Component {
 
   render() {
     return (
-      <Panel>
+      <Panel style={{paddingTop: '0px'}}>
         <div style={{display: 'flex', alignItems: 'center'}}>
-          <h5 style={{flexGrow: 1}}>
+          <h4 style={{flexGrow: 1}}>
             {this.props.categoryName}
-          </h5>
-          <Label bsStyle="danger">
-            {this.props.categoryMatch}%
-          </Label>
+          </h4>
+          <CandidateMatchRating
+            compositeMatchScore={this.props.categoryMatch} />
         </div>
       </Panel>
     )

--- a/assets/js/components/organisms/CandidateMatchCategory.jsx
+++ b/assets/js/components/organisms/CandidateMatchCategory.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes, Component } from 'react'
-import { Panel, Label } from 'react-bootstrap'
+import { Panel } from 'react-bootstrap'
 
 import CandidateMatchRating from '../atoms/CandidateMatchRating.jsx'
 

--- a/assets/style/main.css
+++ b/assets/style/main.css
@@ -10,3 +10,8 @@ body, html {
     font-size: 48px;
     padding: 3px 0;
 }
+
+.candidate-card .collapse > .panel-body {
+    padding-left: 0px;
+    padding-right: 0px;
+}

--- a/test/frontend/components/atoms/CardSpec.js
+++ b/test/frontend/components/atoms/CardSpec.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import TestUtils from 'react-addons-test-utils'
+import { expect } from 'chai'
+
+import Card from '../../../../assets/js/components/atoms/Card'
+
+describe('The card component', () => {
+  let card, style, children, className
+
+  beforeEach(() => {
+    style = { someRule: 'test-value' }
+    children = [ 'first child', 'second child' ]
+    className = 'garbage-test'
+    card = TestUtils.renderIntoDocument(
+      <Card className={className} style={style}>
+        {children}
+      </Card>
+    )
+  })
+
+  it('will exist', () => {
+    expect(card).to.be.ok
+  })
+
+  it('will have a style property', () => {
+    expect(card).to.have.property('props')
+      .that.have.property('style')
+      .that.equal(style)
+  })
+
+  it('will have a children property', () => {
+    expect(card).to.have.property('props')
+      .that.have.property('children')
+      .that.equal(children)
+  })
+
+  it('will have a className property', () => {
+    expect(card).to.have.property('props')
+      .that.have.property('className')
+      .that.equal(className)
+  })
+
+  context('section', () => {
+    let section
+
+    beforeEach(() => {
+      section = TestUtils.scryRenderedDOMComponentsWithTag(card, 'section')[0]
+    })
+
+    it('will exist', () => {
+      expect(section).to.be.ok
+    })
+
+    it('will have the parent class name', () => {
+      expect(section).to.have.property('className')
+        .that.equal(className)
+    })
+  })
+})

--- a/test/frontend/components/organisms/CandidateMatchCandidateSpec.js
+++ b/test/frontend/components/organisms/CandidateMatchCandidateSpec.js
@@ -7,6 +7,7 @@ import CandidateMatchCandidate
   from '../../../../assets/js/components/organisms/CandidateMatchCandidate'
 import CandidateMatchProfileBadge
   from '../../../../assets/js/components/molecules/CandidateMatchProfileBadge'
+import Card from '../../../../assets/js/components/atoms/Card'
 
 describe('The results candidate component', () => {
   let candidate
@@ -22,128 +23,147 @@ describe('The results candidate component', () => {
     expect(candidate).to.be.ok
   })
 
-  context('flexbox', () => {
-    let flexbox
+  context('card', () => {
+    let card
 
     beforeEach(() => {
-      flexbox = TestUtils.scryRenderedDOMComponentsWithTag(candidate, 'div')[0]
+      card = TestUtils.scryRenderedComponentsWithType(candidate, Card)[0]
     })
 
     it('will exist', () => {
-      expect(flexbox).to.be.ok
+      expect(card).to.be.ok
     })
 
-    it('will have a flex display style', () => {
-      expect(flexbox).to.have.property('style')
-        .that.is.an('object')
-        .that.have.property('display')
-        .that.is.a('string')
-        .that.equal('flex')
+    it('will have a candidate-card class', () => {
+      expect(card).to.have.property('props')
+        .that.have.property('className')
+        .that.equal('candidate-card')
     })
 
-    context('button', () => {
-      let button
+    context('flexbox', () => {
+      let flexbox
 
       beforeEach(() => {
-        button = TestUtils.scryRenderedComponentsWithType(candidate, Button)[0]
+        flexbox = TestUtils.scryRenderedDOMComponentsWithTag(card, 'div')[0]
       })
 
       it('will exist', () => {
-        expect(button).to.be.ok
+        expect(flexbox).to.be.ok
       })
 
-      it('will have a downwards chevron for an icon', () => {
-        let icon =
-          TestUtils.scryRenderedComponentsWithType(button, Glyphicon)[0]
-        expect(icon).to.have.property('props')
-          .that.have.property('glyph')
-          .that.equal('chevron-down')
+      it('will have a flex display style', () => {
+        expect(flexbox).to.have.property('style')
+          .that.is.an('object')
+          .that.have.property('display')
+          .that.is.a('string')
+          .that.equal('flex')
       })
 
-      context('onclick', () => {
-        let onclick
+      context('button', () => {
+        let button
 
         beforeEach(() => {
-          onclick = button.props.onClick
+          button = TestUtils.scryRenderedComponentsWithType(card, Button)[0]
         })
 
         it('will exist', () => {
-          expect(onclick).to.be.ok
+          expect(button).to.be.ok
         })
 
-        it('will toggle the showCategory state', () => {
-          onclick()
-          expect(candidate.state.showCategory).to.be.true
-        })
-
-        it('will show an upwards chevron for an icon', () => {
+        it('will have a downwards chevron for an icon', () => {
           let icon =
             TestUtils.scryRenderedComponentsWithType(button, Glyphicon)[0]
-          onclick()
           expect(icon).to.have.property('props')
             .that.have.property('glyph')
-            .that.equal('chevron-up')
+            .that.equal('chevron-down')
+        })
+
+        context('onclick', () => {
+          let onclick
+
+          beforeEach(() => {
+            onclick = button.props.onClick
+          })
+
+          it('will exist', () => {
+            expect(onclick).to.be.ok
+          })
+
+          it('will toggle the showCategory state', () => {
+            onclick()
+            expect(candidate.state.showCategory).to.be.true
+          })
+
+          it('will show an upwards chevron for an icon', () => {
+            let icon =
+              TestUtils.scryRenderedComponentsWithType(button, Glyphicon)[0]
+            onclick()
+            expect(icon).to.have.property('props')
+              .that.have.property('glyph')
+              .that.equal('chevron-up')
+          })
+        })
+      })
+
+      context('badge', () => {
+        let badge
+
+        beforeEach(() => {
+          badge =
+            TestUtils.scryRenderedComponentsWithType(
+              card, CandidateMatchProfileBadge)[0]
+        })
+
+        it('will exist', () => {
+          expect(badge).to.be.ok
+        })
+
+        it('will have a flex style property of 1', () => {
+          expect(badge).to.have.property('props')
+            .that.have.property('style')
+            .that.have.property('flex')
+            .that.equal(1)
         })
       })
     })
 
-    context('badge', () => {
-      let badge
+    context('panel', () => {
+      let panel
 
       beforeEach(() => {
-        badge =
-          TestUtils.scryRenderedComponentsWithType(
-            candidate, CandidateMatchProfileBadge)[0]
+        panel = TestUtils.scryRenderedComponentsWithType(card, Panel)[0]
       })
 
       it('will exist', () => {
-        expect(badge).to.be.ok
+        expect(panel).to.be.ok
       })
 
-      it('will have a flex style property of 1', () => {
-        expect(badge).to.have.property('props')
+      it('will have a collapsible property', () => {
+        expect(panel).to.have.property('props')
+          .that.have.property('collapsible')
+          .that.is.true
+      })
+
+      it('will have an expanded property', () => {
+        expect(panel).to.have.property('props')
+          .that.have.property('expanded')
+          .that.equal(candidate.state.showCategory)
+      })
+
+      it('will have a borderless style', () => {
+        expect(panel).to.have.property('props')
           .that.have.property('style')
-          .that.have.property('flex')
-          .that.equal(1)
+          .that.have.property('border')
+          .that.equal('none')
+      })
+
+      it('will have an unset box-shadow style', () => {
+        expect(panel).to.have.property('props')
+          .that.have.property('style')
+          .that.have.property('boxShadow')
+          .that.equal('none')
       })
     })
   })
 
-  context('panel', () => {
-    let panel
-
-    beforeEach(() => {
-      panel = TestUtils.scryRenderedComponentsWithType(candidate, Panel)[0]
-    })
-
-    it('will exist', () => {
-      expect(panel).to.be.ok
-    })
-
-    it('will have a collapsible property', () => {
-      expect(panel).to.have.property('props')
-        .that.have.property('collapsible')
-        .that.is.true
-    })
-
-    it('will have an expanded property', () => {
-      expect(panel).to.have.property('props')
-        .that.have.property('expanded')
-        .that.equal(candidate.state.showCategory)
-    })
-
-    it('will have a borderless style', () => {
-      expect(panel).to.have.property('props')
-        .that.have.property('style')
-        .that.have.property('border')
-        .that.equal('none')
-    })
-
-    it('will have an unset box-shadow style', () => {
-      expect(panel).to.have.property('props')
-        .that.have.property('style')
-        .that.have.property('boxShadow')
-        .that.equal('none')
-    })
-  })
 })

--- a/test/frontend/components/organisms/CandidateMatchCategorySpec.js
+++ b/test/frontend/components/organisms/CandidateMatchCategorySpec.js
@@ -1,0 +1,121 @@
+import React from 'react'
+import { Panel, Label } from 'react-bootstrap'
+import TestUtils from 'react-addons-test-utils'
+import { expect } from 'chai'
+
+import CandidateMatchCategory
+  from '../../../../assets/js/components/organisms/CandidateMatchCategory'
+
+describe('The candidate match category component', () => {
+  let category
+
+  beforeEach(() => {
+    category = TestUtils.renderIntoDocument(
+      <CandidateMatchCategory
+        categoryName="Test Category"
+        categoryMatch="94"
+        questions={[]} />
+    )
+  })
+
+  it('will exist', () => {
+    expect(category).to.be.ok
+  })
+
+  it('will have a categoryName property', () => {
+    expect(category).to.have.property('props')
+      .that.have.property('categoryName')
+      .that.is.a('string')
+      .that.not.empty
+  })
+
+  it('will have a categoryMatch property', () => {
+    expect(category).to.have.property('props')
+      .that.have.property('categoryMatch')
+      .that.is.a('string')
+      .that.not.empty
+  })
+
+  context('panel', () => {
+    let panel
+
+    beforeEach(() => {
+      panel = TestUtils.scryRenderedComponentsWithType(category, Panel)[0]
+    })
+
+    it('will exist', () => {
+      expect(panel).to.be.ok
+    })
+
+    context('div', () => {
+      let div
+
+      beforeEach(() => {
+        // why is this the third one in?
+        div = TestUtils.scryRenderedDOMComponentsWithTag(panel, 'div')[2]
+      })
+
+      it('will exist', () => {
+        expect(div).to.be.ok
+      })
+
+      it('will have a flex display style', () => {
+        expect(div).to.have.property('style')
+          .that.have.property('display')
+          .that.equal('flex')
+      })
+
+      it('will align its items in the center', () => {
+        expect(div).to.have.property('style')
+          .that.have.property('alignItems')
+          .that.equal('center')
+      })
+    })
+
+    context('header', () => {
+      let header
+
+      beforeEach(() => {
+        header = TestUtils.scryRenderedDOMComponentsWithTag(panel, 'h5')[0]
+      })
+
+      it('will exist', () => {
+        expect(header).to.be.ok
+      })
+
+      it('will include the category name in its text', () => {
+        expect(header).to.have.property('textContent')
+          .that.include(category.props.categoryName)
+      })
+
+      it('will have a flex-grow of 1', () => {
+        expect(header).to.have.property('style')
+          .that.have.property('flexGrow')
+          .that.equal('1')
+      })
+    })
+
+    context('label', () => {
+      let label
+
+      beforeEach(() => {
+        label = TestUtils.scryRenderedComponentsWithType(panel, Label)[0]
+      })
+
+      it('will exist', () => {
+        expect(label).to.be.ok
+      })
+
+      it('will have a danger bsStyle', () => {
+        expect(label).to.have.property('props')
+          .that.have.property('bsStyle')
+          .that.equal('danger')
+      })
+
+      it('will have the match as a percentage for its children', () => {
+        expect(label.props.children.join(''))
+          .to.equal(`${category.props.categoryMatch}%`)
+      })
+    })
+  })
+})

--- a/test/frontend/components/organisms/CandidateMatchCategorySpec.js
+++ b/test/frontend/components/organisms/CandidateMatchCategorySpec.js
@@ -1,10 +1,14 @@
 import React from 'react'
-import { Panel, Label } from 'react-bootstrap'
+import ReactDOM from 'react-dom'
+import { Panel } from 'react-bootstrap'
 import TestUtils from 'react-addons-test-utils'
 import { expect } from 'chai'
 
 import CandidateMatchCategory
   from '../../../../assets/js/components/organisms/CandidateMatchCategory'
+
+import CandidateMatchRating
+  from '../../../../assets/js/components/atoms/CandidateMatchRating'
 
 describe('The candidate match category component', () => {
   let category
@@ -76,7 +80,7 @@ describe('The candidate match category component', () => {
       let header
 
       beforeEach(() => {
-        header = TestUtils.scryRenderedDOMComponentsWithTag(panel, 'h5')[0]
+        header = TestUtils.scryRenderedDOMComponentsWithTag(panel, 'h4')[0]
       })
 
       it('will exist', () => {
@@ -95,26 +99,21 @@ describe('The candidate match category component', () => {
       })
     })
 
-    context('label', () => {
-      let label
+    context('match rating', () => {
+      let rating
 
       beforeEach(() => {
-        label = TestUtils.scryRenderedComponentsWithType(panel, Label)[0]
+        rating = TestUtils.scryRenderedComponentsWithType(panel,
+          CandidateMatchRating)[0]
       })
 
       it('will exist', () => {
-        expect(label).to.be.ok
+        expect(rating).to.exist
       })
 
-      it('will have a danger bsStyle', () => {
-        expect(label).to.have.property('props')
-          .that.have.property('bsStyle')
-          .that.equal('danger')
-      })
-
-      it('will have the match as a percentage for its children', () => {
-        expect(label.props.children.join(''))
-          .to.equal(`${category.props.categoryMatch}%`)
+      it('will have the match as a percentage for its text content', () => {
+        expect(ReactDOM.findDOMNode(rating).textContent)
+          .to.contain(`${category.props.categoryMatch}%`)
       })
     })
   })


### PR DESCRIPTION
Display a single row containing the category name and match in place of
the more detailed match report.

Signed-off-by: Ryan Y <ryayak1460@protingumas.com>