### PR TITLE
Change initial alerts to object

### DIFF
--- a/assets/js/components/ecosystems/SurveyQuestionPager.jsx
+++ b/assets/js/components/ecosystems/SurveyQuestionPager.jsx
@@ -27,7 +27,7 @@ class SurveyQuestionPager extends Component {
     super(props)
     this.state = {
       index: 0,
-      alerts: [],
+      alerts: {},
       finalSkip: false
     }
   }

--- a/test/frontend/components/ecosystems/SurveyQuestionPagerTest.js
+++ b/test/frontend/components/ecosystems/SurveyQuestionPagerTest.js
@@ -12,22 +12,25 @@ describe('Survey Question Pager', () => {
 
   let component, stub
 
+  beforeEach(() => {
+    stub = sinon.stub(browserHistory, 'push', (() => true))
+
+    component = TestUtils.renderIntoDocument(
+      <SurveyQuestionPager questions={questions} />
+    )
+  })
+
+  it('will exist', () => {
+    expect(component).to.be.ok
+  })
+
+  it('will have an initial alerts object in its state', () => {
+    expect(component).to.have.property('state')
+      .that.have.property('alerts')
+      .that.is.an('object')
+  })
+
   context('Survey Question Pager', () => {
-
-    beforeEach(() => {
-
-      stub = sinon.stub(browserHistory, 'push', (() => true))
-
-      component = TestUtils.renderIntoDocument(
-        <SurveyQuestionPager questions={questions} />
-      )
-    })
-
-    afterEach(() => {
-
-      stub.restore()
-
-    })
 
     context('Back Button', () => {
 
@@ -110,4 +113,7 @@ describe('Survey Question Pager', () => {
 
   })
 
+  afterEach(() => {
+    stub.restore()
+  })
 })


### PR DESCRIPTION
The alerts in the survey question state needs an object instead of an
array.  Default it to this.

Signed-off-by: Ryan Y <ryayak1460@protingumas.com>