### PR TITLE
133 google analytics isnt working

### DIFF
--- a/assets/js/components/Index.jsx
+++ b/assets/js/components/Index.jsx
@@ -2,6 +2,7 @@ import React, { Component} from 'react';
 import ReactDOM from 'react-dom'
 import { IndexRoute, Router, Route, browserHistory } from 'react-router'
 import { Provider } from 'react-redux'
+import ga from 'react-ga'
 import { applyMiddleware, createStore } from 'redux'
 import reducer from './../redux/reducer'
 import createLogger from 'redux-logger'
@@ -21,10 +22,12 @@ import WardFinderPage from './ecosystems/WardFinderPage.jsx'
 import ResultsPage from './ecosystems/ResultsPage.jsx'
 import SurveyPage from './ecosystems/SurveyPage.jsx'
 
+ga.initialize('UA-39303796-10')
+
 class App extends Component {
   render() {
     return (
-      <Router history={browserHistory}>
+      <Router history={browserHistory} onUpdate={() => ga.pageView(this.state.location.pathname)}>
         <Route path="/" component={Frame}>
           <IndexRoute component={WardFinderPage} />
           <Route path="survey" component={SurveyPage} />
@@ -42,3 +45,5 @@ ReactDOM.render(
   </Provider>,
   document.body
 );
+
+export default App

--- a/assets/js/components/Index.jsx
+++ b/assets/js/components/Index.jsx
@@ -23,11 +23,15 @@ import ResultsPage from './ecosystems/ResultsPage.jsx'
 import SurveyPage from './ecosystems/SurveyPage.jsx'
 
 ga.initialize('UA-39303796-10')
+browserHistory.listen(location => {
+  ga.pageview(location.pathname)
+})
 
 class App extends Component {
+
   render() {
     return (
-      <Router history={browserHistory} onUpdate={() => ga.pageView(this.state.location.pathname)}>
+      <Router history={browserHistory}>
         <Route path="/" component={Frame}>
           <IndexRoute component={WardFinderPage} />
           <Route path="survey" component={SurveyPage} />

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-addons-test-utils": "^0.14.7",
     "react-bootstrap": "^0.28.5",
     "react-dom": "^0.14.3",
+    "react-ga": "^1.3.3",
     "react-rating": "^0.2.2",
     "react-redux": "^4.4.0",
     "react-router": "^2.0.0",

--- a/views/Default.jsx
+++ b/views/Default.jsx
@@ -4,16 +4,6 @@ const React = require('react');
 
 const Default = React.createClass({
 
-  componentDidMount() {
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga')
-
-    ga('create', 'UA-39303796-10', 'auto');
-    ga('send', 'pageview');
-  },
-
   render: function() {
 
     return(


### PR DESCRIPTION
Builds on work from @ryayak1460.  The API for React Router changed recently such that the method of recording pageviews in the `react-ga` analytics documentation no longer worked.  Work around is to listen for changes on the browserHistory singleton. Fixes #133 