### PR TITLE
Use environment variable for analytics key

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ export OKC_DB_USER=username
 export OKC_DB_PASSWORD=password
 export SMARTY_STREETS_AUTH_ID=smartystreetsauthid
 export SMARTY_STREETS_AUTH_TOKEN=smartystreetsauthtoken
+export GOOGLE_ANALYTICS=UC-12345678-90
 ```
 ... replacing `databasename`, `username`, and `password` with the information used during setup of the database.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ export OKC_DB_USER=username
 export OKC_DB_PASSWORD=password
 export SMARTY_STREETS_AUTH_ID=smartystreetsauthid
 export SMARTY_STREETS_AUTH_TOKEN=smartystreetsauthtoken
-export GOOGLE_ANALYTICS=UC-12345678-90
+export GOOGLE_ANALYTICS=UA-12345678-90
 ```
 ... replacing `databasename`, `username`, and `password` with the information used during setup of the database.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ export OKC_DB_USER=username
 export OKC_DB_PASSWORD=password
 export SMARTY_STREETS_AUTH_ID=smartystreetsauthid
 export SMARTY_STREETS_AUTH_TOKEN=smartystreetsauthtoken
-export GOOGLE_ANALYTICS=UA-12345678-90
+export GOOGLE_ANALYTICS=UA-39303796-11
 ```
 ... replacing `databasename`, `username`, and `password` with the information used during setup of the database.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ When you open a pull request, please ask to merge against the `develop` branch. 
 
 ## Installation
 ```
+sudo npm install -g envify
 git clone git@github.com:Code4HR/okcandidate.git
 npm install
 npm run dev

--- a/assets/js/components/Index.jsx
+++ b/assets/js/components/Index.jsx
@@ -24,7 +24,7 @@ import WardFinderPage from './ecosystems/WardFinderPage.jsx'
 import ResultsPage from './ecosystems/ResultsPage.jsx'
 import SurveyPage from './ecosystems/SurveyPage.jsx'
 
-ga.initialize(process.env['GOOGLE_ANALYTICS'])
+ga.initialize(process.env.GOOGLE_ANALYTICS)
 browserHistory.listen(location => {
   ga.pageview(location.pathname)
 })

--- a/assets/js/components/Index.jsx
+++ b/assets/js/components/Index.jsx
@@ -24,7 +24,7 @@ import WardFinderPage from './ecosystems/WardFinderPage.jsx'
 import ResultsPage from './ecosystems/ResultsPage.jsx'
 import SurveyPage from './ecosystems/SurveyPage.jsx'
 
-ga.initialize('UA-39303796-10')
+ga.initialize(process.env['GOOGLE_ANALYTICS'])
 browserHistory.listen(location => {
   ga.pageview(location.pathname)
 })

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "browser-sync-webpack-plugin": "^1.0.1",
     "chai": "^3.5.0",
     "css-loader": "^0.23.1",
+    "envify-loader": "^0.1.0",
     "eslint": "^2.3.0",
     "eslint-config-trails": "^1.0.4",
     "eslint-loader": "^1.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,10 @@ module.exports = {
     loaders: [
       {
         test: /\.jsx$|\.js$/,
+        loader: 'envify-loader',
+        exclude: /node_modules/
+      }, {
+        test: /\.jsx$|\.js$/,
         loader: 'babel-loader',
         exclude: /node_modules/
       }, {


### PR DESCRIPTION
Use GOOGLE_ANALYTICS for the Google Analytics id instead of a
hard-coded, publicly available value everyone can see.  Update the
documentation to reflect this.

Signed-off-by: Ryan Y <ryayak1460@protingumas.com>