### PR TITLE
Add a boolean flag 'hasContactInfo' to response to show that we have …

### DIFF
--- a/api/controllers/Candidate.js
+++ b/api/controllers/Candidate.js
@@ -3,6 +3,7 @@ const _ = require('lodash')
 module.exports = function (server) {
   const Candidate = server.plugins['hapi-shelf'].model('Candidate')
   const SurveyAnswer = server.plugins['hapi-shelf'].model('SurveyAnswer')
+  const SurveyResponse = server.plugins['hapi-shelf'].model('SurveyResponse')
 
   function getCandidateMatch(surveyResponseId, callback)
   {
@@ -161,8 +162,22 @@ module.exports = function (server) {
     method: 'GET',
     path: '/api/candidate_match/{survey_response_id}',
     handler: (request, reply) => {
-      getCandidateMatch(request.params.survey_response_id, (matches) => {
-        reply(matches)
+
+      const responseId = request.params.survey_response_id
+
+      Promise.all([
+        SurveyResponse
+          .where({id: responseId})
+          .fetch(),
+        new Promise(resolve => {
+          getCandidateMatch(responseId, matches => {
+            resolve(matches)
+          })
+        })
+      ]).then(results => {
+        const info = results[0].toJSON()
+        const hasContactInfo = Boolean(info.userEmail || info.userPhone)
+        reply(Object.assign({}, results[1], {hasContactInfo}))
       })
     }
   }]

--- a/assets/js/components/ecosystems/ResultsPage.jsx
+++ b/assets/js/components/ecosystems/ResultsPage.jsx
@@ -54,10 +54,13 @@ class ResultsPage extends Component {
           <Row>
             <Col xs={12} sm={8} smOffset={2}>
 
-              <ElectionDayReminder
-                electionDayReminder={this.props.survey.electionDayReminder}
-                surveyId={this.props.survey.surveyResponseId}
-                dispatch={this.props.dispatch} />
+              {
+                !this.props.survey.candidateMatch.hasContactInfo &&
+                <ElectionDayReminder
+                  electionDayReminder={this.props.survey.electionDayReminder}
+                  surveyId={this.props.survey.surveyResponseId}
+                  dispatch={this.props.dispatch} />
+              }
 
               <SurveyCompletionIndicator
                 questionsAnswered={this.props.survey.responses.length}


### PR DESCRIPTION
…already collected the user's contact info.

Don't show contact info prompt if we already have the user's contact info. Fixes #202