### PR TITLE
Update input placeholder for Virginia Beach.

### DIFF
--- a/assets/js/components/ecosystems/WardFinderPage.jsx
+++ b/assets/js/components/ecosystems/WardFinderPage.jsx
@@ -100,7 +100,7 @@ class WardFinderPage extends Component {
                 <Card style={style.card}>
                   <h2>Get Started!</h2>
                   <p>
-                    We can find candidates running for office in your area by using any Norfolk
+                    We can find candidates running for office in your area by using any Virginia Beach
                     street address.
                   </p>
                   <WardFinderAddress

--- a/assets/js/components/organisms/WardFinderAddress.jsx
+++ b/assets/js/components/organisms/WardFinderAddress.jsx
@@ -55,7 +55,7 @@ class WardFinderAddress extends Component {
               label="Street Address"
               onChange={this.onSetAddress.bind(this)}
               value={this.props.ward.address.value}
-              placeholder="111 Granby St"
+              placeholder="1906 Deer Park Drive"
               onKeyDown={this.onEnter.bind(this)}/>
             <InputGroup.Button>
               <Button

--- a/assets/js/components/organisms/WardFinderAddress.jsx
+++ b/assets/js/components/organisms/WardFinderAddress.jsx
@@ -55,7 +55,7 @@ class WardFinderAddress extends Component {
               label="Street Address"
               onChange={this.onSetAddress.bind(this)}
               value={this.props.ward.address.value}
-              placeholder="1906 Deer Park Drive"
+              placeholder="1701 Baltic Ave"
               onKeyDown={this.onEnter.bind(this)}/>
             <InputGroup.Button>
               <Button


### PR DESCRIPTION
Replace reference to Norfolk with Virginia Beach in splash page text. Fixes #206 