### PR TITLE
Autoblur select field.

### DIFF
--- a/assets/js/components/organisms/NeighborhoodTypeahead.jsx
+++ b/assets/js/components/organisms/NeighborhoodTypeahead.jsx
@@ -32,6 +32,7 @@ class NeighborhoodFinder extends Component {
   render() {
     return (
       <Select
+        autoBlur
         style={{marginBottom: '.5em'}}
         clearable={false}
         name="form-field-name"


### PR DESCRIPTION
On iOS, the typeahead component wasn't autoblurring after a selection was made, which caused the software keyboard to appear when selecting responses.